### PR TITLE
Allow equality checks of Rules and make sure listing rules gives us the information we need.

### DIFF
--- a/rule.go
+++ b/rule.go
@@ -48,6 +48,9 @@ func (r Rule) Equal(x Rule) bool {
 		r.IPProto == x.IPProto &&
 		r.Protocol == x.Protocol &&
 		r.Mark == x.Mark &&
+		// For non-zero marks, mask defaults to 0xFFFFFFFF if not set. So if either mask is nil
+		// while the other is 0xFFFFFFFF when mark is non-zero, treat the masks as identical.
+		// See kernel source: https://github.com/torvalds/linux/blob/v6.15/net/core/fib_rules.c#L624
 		(ptrEqual(r.Mask, x.Mask) || (r.Mark != 0 &&
 			(r.Mask == nil && *x.Mask == 0xFFFFFFFF || x.Mask == nil && *r.Mask == 0xFFFFFFFF))) &&
 		r.TunID == x.TunID &&

--- a/rule.go
+++ b/rule.go
@@ -31,6 +31,34 @@ type Rule struct {
 	Type              uint8
 }
 
+func (r Rule) Equal(x Rule) bool {
+	return r.Table == x.Table &&
+		((r.Src == nil && x.Src == nil) ||
+			(r.Src != nil && x.Src != nil && r.Src.String() == x.Src.String())) &&
+		((r.Dst == nil && x.Dst == nil) ||
+			(r.Dst != nil && x.Dst != nil && r.Dst.String() == x.Dst.String())) &&
+		r.OifName == x.OifName &&
+		r.Priority == x.Priority &&
+		r.Family == x.Family &&
+		r.IifName == x.IifName &&
+		r.Invert == x.Invert &&
+		r.Tos == x.Tos &&
+		r.Type == x.Type &&
+		r.IPProto == x.IPProto &&
+		r.Protocol == x.Protocol &&
+		r.Mark == x.Mark &&
+		(ptrEqual(r.Mask, x.Mask) || (r.Mark != 0 &&
+			(r.Mask == nil && *x.Mask == 0xFFFFFFFF || x.Mask == nil && *r.Mask == 0xFFFFFFFF))) &&
+		r.TunID == x.TunID &&
+		r.Goto == x.Goto &&
+		r.Flow == x.Flow &&
+		r.SuppressIfgroup == x.SuppressIfgroup &&
+		r.SuppressPrefixlen == x.SuppressPrefixlen &&
+		(r.Dport == x.Dport || (r.Dport != nil && x.Dport != nil && r.Dport.Equal(*x.Dport))) &&
+		(r.Sport == x.Sport || (r.Sport != nil && x.Sport != nil && r.Sport.Equal(*x.Sport))) &&
+		(r.UIDRange == x.UIDRange || (r.UIDRange != nil && x.UIDRange != nil && r.UIDRange.Equal(*x.UIDRange)))
+}
+
 func (r Rule) String() string {
 	from := "all"
 	if r.Src != nil && r.Src.String() != "<nil>" {
@@ -70,6 +98,10 @@ type RulePortRange struct {
 	End   uint16
 }
 
+func (r RulePortRange) Equal(x RulePortRange) bool {
+	return r.Start == x.Start && r.End == x.End
+}
+
 // NewRuleUIDRange creates rule uid range.
 func NewRuleUIDRange(start, end uint32) *RuleUIDRange {
 	return &RuleUIDRange{Start: start, End: end}
@@ -79,4 +111,8 @@ func NewRuleUIDRange(start, end uint32) *RuleUIDRange {
 type RuleUIDRange struct {
 	Start uint32
 	End   uint32
+}
+
+func (r RuleUIDRange) Equal(x RuleUIDRange) bool {
+	return r.Start == x.Start && r.End == x.End
 }

--- a/rule.go
+++ b/rule.go
@@ -29,6 +29,7 @@ type Rule struct {
 	UIDRange          *RuleUIDRange
 	Protocol          uint8
 	Type              uint8
+	L3mdev            uint8
 }
 
 func (r Rule) Equal(x Rule) bool {
@@ -56,7 +57,8 @@ func (r Rule) Equal(x Rule) bool {
 		r.SuppressPrefixlen == x.SuppressPrefixlen &&
 		(r.Dport == x.Dport || (r.Dport != nil && x.Dport != nil && r.Dport.Equal(*x.Dport))) &&
 		(r.Sport == x.Sport || (r.Sport != nil && x.Sport != nil && r.Sport.Equal(*x.Sport))) &&
-		(r.UIDRange == x.UIDRange || (r.UIDRange != nil && x.UIDRange != nil && r.UIDRange.Equal(*x.UIDRange)))
+		(r.UIDRange == x.UIDRange || (r.UIDRange != nil && x.UIDRange != nil && r.UIDRange.Equal(*x.UIDRange))) &&
+		r.L3mdev == x.L3mdev
 }
 
 func (r Rule) String() string {

--- a/rule_linux.go
+++ b/rule_linux.go
@@ -226,6 +226,7 @@ func (h *Handle) RuleListFiltered(family int, filter *Rule, filterMask uint64) (
 		rule.Invert = msg.Flags&FibRuleInvert > 0
 		rule.Family = int(msg.Family)
 		rule.Tos = uint(msg.Tos)
+		rule.Type = msg.Type
 
 		for j := range attrs {
 			switch attrs[j].Attr.Type {
@@ -278,6 +279,8 @@ func (h *Handle) RuleListFiltered(family int, filter *Rule, filterMask uint64) (
 				rule.UIDRange = NewRuleUIDRange(native.Uint32(attrs[j].Value[0:4]), native.Uint32(attrs[j].Value[4:8]))
 			case nl.FRA_PROTOCOL:
 				rule.Protocol = uint8(attrs[j].Value[0])
+			case nl.FRA_L3MDEV:
+				rule.L3mdev = uint8(attrs[j].Value[0])
 			}
 		}
 

--- a/rule_test.go
+++ b/rule_test.go
@@ -707,24 +707,22 @@ func TestRuleEqual(t *testing.T) {
 	}
 }
 
-func TestRuleEqualmaskMark(t *testing.T) {
-	expected := true // These are equal
-	m := &[]uint32{0xFFFFFFFF}[0]
-	cases := []Rule{
-		{Mark: 1, Mask: nil},
-		{Mark: 1, Mask: m},
-		{Mark: 1, Mask: &[]uint32{0xFFFFFFFF}[0]},
+func TestRuleEqualMaskMark(t *testing.T) {
+	a := Rule{Mark: 1, Mask: nil}
+	b := Rule{Mark: 1, Mask: &[]uint32{0xFFFFFFFF}[0]}
+	if !a.Equal(b) || !b.Equal(a) {
+		t.Errorf("Rules are expected to be equal")
 	}
-	for i1 := range cases {
-		for i2 := range cases {
-			got := cases[i1].Equal(cases[i2])
-			if got != expected {
-				t.Errorf("Equal(%q,%q) == %s but expected %s",
-					cases[i1], cases[i2],
-					strconv.FormatBool(got),
-					strconv.FormatBool(expected))
-			}
-		}
+
+	b = Rule{Mark: 2, Mask: &[]uint32{0xFFFFFFFF}[0]}
+	if a.Equal(b) || b.Equal(a) {
+		t.Errorf("Rules are not expected to be equal")
+	}
+
+	a = Rule{Mark: 0, Mask: nil}
+	b = Rule{Mark: 0, Mask: &[]uint32{0xFFFFFFFF}[0]}
+	if a.Equal(b) || b.Equal(a) {
+		t.Errorf("Rules are not expected to be equal")
 	}
 }
 

--- a/rule_test.go
+++ b/rule_test.go
@@ -691,6 +691,7 @@ func TestRuleEqual(t *testing.T) {
 		{UIDRange: &RuleUIDRange{Start: 3, End: 5}},
 		{Protocol: FAMILY_V6},
 		{Type: unix.RTN_UNREACHABLE},
+		{L3mdev: 1},
 	}
 	for i1 := range cases {
 		for i2 := range cases {

--- a/rule_test.go
+++ b/rule_test.go
@@ -5,6 +5,7 @@ package netlink
 
 import (
 	"net"
+	"strconv"
 	"testing"
 
 	"golang.org/x/sys/unix"
@@ -592,7 +593,7 @@ func runRuleListFiltered(t *testing.T, family int, srcNet, dstNet *net.IPNet) {
 				t.Errorf("Expected len: %d, got: %d", len(wantRules), len(rules))
 			} else {
 				for i := range wantRules {
-					if !ruleEquals(wantRules[i], rules[i]) {
+					if !wantRules[i].Equal(rules[i]) {
 						t.Errorf("Rules mismatch, want %v, got %v", wantRules[i], rules[i])
 					}
 				}
@@ -658,7 +659,7 @@ func TestRuleString(t *testing.T) {
 
 func ruleExists(rules []Rule, rule Rule) bool {
 	for i := range rules {
-		if ruleEquals(rules[i], rule) {
+		if rules[i].Equal(rule) {
 			return true
 		}
 	}
@@ -666,22 +667,102 @@ func ruleExists(rules []Rule, rule Rule) bool {
 	return false
 }
 
-func ruleEquals(a, b Rule) bool {
-	return a.Table == b.Table &&
-		((a.Src == nil && b.Src == nil) ||
-			(a.Src != nil && b.Src != nil && a.Src.String() == b.Src.String())) &&
-		((a.Dst == nil && b.Dst == nil) ||
-			(a.Dst != nil && b.Dst != nil && a.Dst.String() == b.Dst.String())) &&
-		a.OifName == b.OifName &&
-		a.Priority == b.Priority &&
-		a.Family == b.Family &&
-		a.IifName == b.IifName &&
-		a.Invert == b.Invert &&
-		a.Tos == b.Tos &&
-		a.Type == b.Type &&
-		a.IPProto == b.IPProto &&
-		a.Protocol == b.Protocol &&
-		a.Mark == b.Mark &&
-		(ptrEqual(a.Mask, b.Mask) || (a.Mark != 0 &&
-			(a.Mask == nil && *b.Mask == 0xFFFFFFFF || b.Mask == nil && *a.Mask == 0xFFFFFFFF)))
+func TestRuleEqual(t *testing.T) {
+	cases := []Rule{
+		{Priority: 1000},
+		{Family: FAMILY_V6},
+		{Table: 10},
+		{Mark: 1},
+		{Mask: &[]uint32{0x1}[0]},
+		{Tos: 1},
+		{TunID: 3},
+		{Goto: 10},
+		{Src: &net.IPNet{IP: net.IPv4(172, 16, 0, 1), Mask: net.CIDRMask(16, 32)}},
+		{Dst: &net.IPNet{IP: net.IPv4(172, 16, 1, 1), Mask: net.CIDRMask(24, 32)}},
+		{Flow: 3},
+		{IifName: "IifName"},
+		{OifName: "OifName"},
+		{SuppressIfgroup: 7},
+		{SuppressPrefixlen: 16},
+		{Invert: true},
+		{Dport: &RulePortRange{Start: 10, End: 20}},
+		{Sport: &RulePortRange{Start: 1, End: 2}},
+		{IPProto: unix.IPPROTO_TCP},
+		{UIDRange: &RuleUIDRange{Start: 3, End: 5}},
+		{Protocol: FAMILY_V6},
+		{Type: unix.RTN_UNREACHABLE},
+	}
+	for i1 := range cases {
+		for i2 := range cases {
+			got := cases[i1].Equal(cases[i2])
+			expected := i1 == i2
+			if got != expected {
+				t.Errorf("Equal(%q,%q) == %s but expected %s",
+					cases[i1], cases[i2],
+					strconv.FormatBool(got),
+					strconv.FormatBool(expected))
+			}
+		}
+	}
+}
+
+func TestRuleEqualmaskMark(t *testing.T) {
+	expected := true // These are equal
+	m := &[]uint32{0xFFFFFFFF}[0]
+	cases := []Rule{
+		{Mark: 1, Mask: nil},
+		{Mark: 1, Mask: m},
+		{Mark: 1, Mask: &[]uint32{0xFFFFFFFF}[0]},
+	}
+	for i1 := range cases {
+		for i2 := range cases {
+			got := cases[i1].Equal(cases[i2])
+			if got != expected {
+				t.Errorf("Equal(%q,%q) == %s but expected %s",
+					cases[i1], cases[i2],
+					strconv.FormatBool(got),
+					strconv.FormatBool(expected))
+			}
+		}
+	}
+}
+
+func TestRulePortRangeEqual(t *testing.T) {
+	cases := []RulePortRange{
+		{Start: 10, End: 10},
+		{Start: 10, End: 22},
+		{Start: 11, End: 22},
+	}
+	for i1 := range cases {
+		for i2 := range cases {
+			got := cases[i1].Equal(cases[i2])
+			expected := i1 == i2
+			if got != expected {
+				t.Errorf("Equal(%q,%q) == %s but expected %s",
+					cases[i1], cases[i2],
+					strconv.FormatBool(got),
+					strconv.FormatBool(expected))
+			}
+		}
+	}
+}
+
+func TestRuleUIDRangeEqual(t *testing.T) {
+	cases := []RuleUIDRange{
+		{Start: 10, End: 10},
+		{Start: 10, End: 22},
+		{Start: 11, End: 22},
+	}
+	for i1 := range cases {
+		for i2 := range cases {
+			got := cases[i1].Equal(cases[i2])
+			expected := i1 == i2
+			if got != expected {
+				t.Errorf("Equal(%q,%q) == %s but expected %s",
+					cases[i1], cases[i2],
+					strconv.FormatBool(got),
+					strconv.FormatBool(expected))
+			}
+		}
+	}
 }


### PR DESCRIPTION
While `Route` has a `Equal` function, there is none for `Rule`. So let's add that.

Reading rules didn't populate the `Type` field of `Rule`. It also didn't read whether the `l3mdev` flag was set: let's add that to `Rule` and populate it.